### PR TITLE
[분산 메일 전송] 이하늘 미션 제출합니다. (리더 선출-브로드캐스팅 방식)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+
+db

--- a/.run/mail8080.run.xml
+++ b/.run/mail8080.run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mail8080" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <module name="distributed-mail.main" />
+    <selectedOptions>
+      <option name="environmentVariables" />
+    </selectedOptions>
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.aengdulab.distributedmail.DistributedMailApplication" />
+    <option name="VM_PARAMETERS" value="-Dserver.port=8080" />
+    <extension name="coverage">
+      <pattern>
+        <option name="PATTERN" value="com.aengdulab.distributedmail.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/mail8081.run.xml
+++ b/.run/mail8081.run.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mail8081" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <module name="distributed-mail.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.aengdulab.distributedmail.DistributedMailApplication" />
+    <option name="VM_PARAMETERS" value="-Dserver.port=8081" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/mail8082.run.xml
+++ b/.run/mail8082.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mail8082" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ALTERNATIVE_JRE_PATH" value="corretto-21" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <module name="distributed-mail.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.aengdulab.distributedmail.DistributedMailApplication" />
+    <option name="VM_PARAMETERS" value="-Dserver.port=8082" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/mail8083.run.xml
+++ b/.run/mail8083.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mail8083" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ALTERNATIVE_JRE_PATH" value="corretto-21" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <module name="distributed-mail.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.aengdulab.distributedmail.DistributedMailApplication" />
+    <option name="VM_PARAMETERS" value="-Dserver.port=8083" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/mail8084.run.xml
+++ b/.run/mail8084.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mail8084" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ALTERNATIVE_JRE_PATH" value="corretto-21" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <module name="distributed-mail.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.aengdulab.distributedmail.DistributedMailApplication" />
+    <option name="VM_PARAMETERS" value="-Dserver.port=8084" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/mail8085.run.xml
+++ b/.run/mail8085.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mail8085" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ALTERNATIVE_JRE_PATH" value="corretto-21" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <module name="distributed-mail.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.aengdulab.distributedmail.DistributedMailApplication" />
+    <option name="VM_PARAMETERS" value="-Dserver.port=8085" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/mail8086.run.xml
+++ b/.run/mail8086.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mail8086" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ALTERNATIVE_JRE_PATH" value="corretto-21" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <module name="distributed-mail.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.aengdulab.distributedmail.DistributedMailApplication" />
+    <option name="VM_PARAMETERS" value="-Dserver.port=8086" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/mail8087.run.xml
+++ b/.run/mail8087.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mail8087" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ALTERNATIVE_JRE_PATH" value="corretto-21" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <module name="distributed-mail.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.aengdulab.distributedmail.DistributedMailApplication" />
+    <option name="VM_PARAMETERS" value="-Dserver.port=8087" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/mail8088.run.xml
+++ b/.run/mail8088.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mail8088" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ALTERNATIVE_JRE_PATH" value="corretto-21" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <module name="distributed-mail.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.aengdulab.distributedmail.DistributedMailApplication" />
+    <option name="VM_PARAMETERS" value="-Dserver.port=8088" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/mail8089.run.xml
+++ b/.run/mail8089.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mail8089" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ALTERNATIVE_JRE_PATH" value="corretto-21" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <module name="distributed-mail.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.aengdulab.distributedmail.DistributedMailApplication" />
+    <option name="VM_PARAMETERS" value="-Dserver.port=8089" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/mail8090.run.xml
+++ b/.run/mail8090.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mail8090" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ALTERNATIVE_JRE_PATH" value="corretto-21" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <module name="distributed-mail.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.aengdulab.distributedmail.DistributedMailApplication" />
+    <option name="VM_PARAMETERS" value="-Dserver.port=8090" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/mail8091.run.xml
+++ b/.run/mail8091.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mail8091" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ALTERNATIVE_JRE_PATH" value="corretto-21" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <module name="distributed-mail.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.aengdulab.distributedmail.DistributedMailApplication" />
+    <option name="VM_PARAMETERS" value="-Dserver.port=8091" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/mail8092.run.xml
+++ b/.run/mail8092.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mail8092" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ALTERNATIVE_JRE_PATH" value="corretto-21" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <module name="distributed-mail.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.aengdulab.distributedmail.DistributedMailApplication" />
+    <option name="VM_PARAMETERS" value="-Dserver.port=8092" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/mail8093.run.xml
+++ b/.run/mail8093.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mail8093" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ALTERNATIVE_JRE_PATH" value="corretto-21" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <module name="distributed-mail.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.aengdulab.distributedmail.DistributedMailApplication" />
+    <option name="VM_PARAMETERS" value="-Dserver.port=8093" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/mail8094.run.xml
+++ b/.run/mail8094.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mail8094" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ALTERNATIVE_JRE_PATH" value="corretto-21" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <module name="distributed-mail.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.aengdulab.distributedmail.DistributedMailApplication" />
+    <option name="VM_PARAMETERS" value="-Dserver.port=8094" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/mail8095.run.xml
+++ b/.run/mail8095.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mail8095" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ALTERNATIVE_JRE_PATH" value="corretto-21" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <module name="distributed-mail.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.aengdulab.distributedmail.DistributedMailApplication" />
+    <option name="VM_PARAMETERS" value="-Dserver.port=8095" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/mail8096.run.xml
+++ b/.run/mail8096.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mail8096" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ALTERNATIVE_JRE_PATH" value="corretto-21" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <module name="distributed-mail.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.aengdulab.distributedmail.DistributedMailApplication" />
+    <option name="VM_PARAMETERS" value="-Dserver.port=8096" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/mail8097.run.xml
+++ b/.run/mail8097.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mail8097" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ALTERNATIVE_JRE_PATH" value="corretto-21" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <module name="distributed-mail.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.aengdulab.distributedmail.DistributedMailApplication" />
+    <option name="VM_PARAMETERS" value="-Dserver.port=8097" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/mail8098.run.xml
+++ b/.run/mail8098.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mail8098" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ALTERNATIVE_JRE_PATH" value="corretto-21" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <module name="distributed-mail.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.aengdulab.distributedmail.DistributedMailApplication" />
+    <option name="VM_PARAMETERS" value="-Dserver.port=8098" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/mail8099.run.xml
+++ b/.run/mail8099.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="mail8099" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ALTERNATIVE_JRE_PATH" value="corretto-21" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <module name="distributed-mail.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="com.aengdulab.distributedmail.DistributedMailApplication" />
+    <option name="VM_PARAMETERS" value="-Dserver.port=8099" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,3 +22,18 @@ services:
     ports:
       - "11025:1025"
       - "18025:8025"
+  zookeeper:
+    image: wurstmeister/zookeeper
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+  kafka:
+    image: wurstmeister/kafka:2.12-2.5.0
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: 127.0.0.1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/src/main/java/com/aengdulab/distributedmail/DistributedLock.java
+++ b/src/main/java/com/aengdulab/distributedmail/DistributedLock.java
@@ -1,0 +1,45 @@
+package com.aengdulab.distributedmail;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DistributedLock {
+
+    public boolean tryLock(Connection connection, String key, int timeout) {
+        String sql = "select get_lock(?, ?)";
+
+        try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setString(1, key);
+            preparedStatement.setInt(2, timeout);
+            return getResult(preparedStatement);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private boolean getResult(PreparedStatement preparedStatement) throws SQLException {
+        try (ResultSet resultSet = preparedStatement.executeQuery()) {
+            if (!resultSet.next()) {
+                return false;
+            }
+
+            int result = resultSet.getInt(1);
+            return result == 1;
+        }
+    }
+
+    public void releaseLock(Connection connection, String key) {
+        String sql = "select release_lock(?)";
+
+        try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setString(1, key);
+            preparedStatement.execute();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/aengdulab/distributedmail/DistributedMailApplication.java
+++ b/src/main/java/com/aengdulab/distributedmail/DistributedMailApplication.java
@@ -3,10 +3,8 @@ package com.aengdulab.distributedmail;
 import java.util.concurrent.CountDownLatch;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Bean;
 
-@ConfigurationPropertiesScan
 @SpringBootApplication
 public class DistributedMailApplication {
 

--- a/src/main/java/com/aengdulab/distributedmail/DistributedMailApplication.java
+++ b/src/main/java/com/aengdulab/distributedmail/DistributedMailApplication.java
@@ -1,8 +1,12 @@
 package com.aengdulab.distributedmail;
 
+import java.util.concurrent.CountDownLatch;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Bean;
 
+@ConfigurationPropertiesScan
 @SpringBootApplication
 public class DistributedMailApplication {
 
@@ -10,4 +14,10 @@ public class DistributedMailApplication {
         SpringApplication.run(DistributedMailApplication.class, args);
     }
 
+    @Bean
+    public GlobalLatch globalLatch() {
+        CountDownLatch latch = new CountDownLatch(1);
+
+        return new GlobalLatch(latch);
+    }
 }

--- a/src/main/java/com/aengdulab/distributedmail/DistributedSupport.java
+++ b/src/main/java/com/aengdulab/distributedmail/DistributedSupport.java
@@ -1,0 +1,18 @@
+package com.aengdulab.distributedmail;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+public class DistributedSupport {
+
+    private int index;
+    private int count;
+
+    public boolean isMine(Long id) {
+        return index == ((id % count) + 1);
+    }
+}

--- a/src/main/java/com/aengdulab/distributedmail/FollowerMessage.java
+++ b/src/main/java/com/aengdulab/distributedmail/FollowerMessage.java
@@ -1,0 +1,4 @@
+package com.aengdulab.distributedmail;
+
+public record FollowerMessage(String address) {
+}

--- a/src/main/java/com/aengdulab/distributedmail/FollowerTask.java
+++ b/src/main/java/com/aengdulab/distributedmail/FollowerTask.java
@@ -1,0 +1,50 @@
+package com.aengdulab.distributedmail;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FollowerTask {
+
+    private final ApplicationContext applicationContext;
+    private final GlobalLatch globalLatch;
+    private final DistributedSupport distributedSupport;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public void start() {
+        log.info("clientTask started");
+        String address = createAddress();
+        FollowerMessage message = new FollowerMessage(address);
+        kafkaTemplate.send("loyalty", message);
+        globalLatch.await();
+    }
+
+    @KafkaListener(topics = "leader", groupId = "consumerGroup-" + "#{T(java.util.UUID).randomUUID()})")
+    public void receiveMessage(LeaderMessage leaderMessage) {
+        String address = createAddress();
+        if (address.equals(leaderMessage.address())) {
+            distributedSupport.setIndex(leaderMessage.index());
+            distributedSupport.setCount(leaderMessage.total());
+            globalLatch.countDown();
+        }
+    }
+
+    private String createAddress() {
+        try {
+            String ip = InetAddress.getLocalHost().getHostAddress();
+            int port = applicationContext.getBean(Environment.class).getProperty("server.port", Integer.class, 8080);
+            return ip + ":" + port;
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/aengdulab/distributedmail/GlobalLatch.java
+++ b/src/main/java/com/aengdulab/distributedmail/GlobalLatch.java
@@ -1,0 +1,24 @@
+package com.aengdulab.distributedmail;
+
+import java.util.concurrent.CountDownLatch;
+
+public class GlobalLatch {
+
+    private final CountDownLatch latch;
+
+    public GlobalLatch(CountDownLatch latch) {
+        this.latch = latch;
+    }
+
+    public void await() {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void countDown() {
+        latch.countDown();
+    }
+}

--- a/src/main/java/com/aengdulab/distributedmail/LeaderMessage.java
+++ b/src/main/java/com/aengdulab/distributedmail/LeaderMessage.java
@@ -1,0 +1,4 @@
+package com.aengdulab.distributedmail;
+
+public record LeaderMessage(String address, int total, int index) {
+}

--- a/src/main/java/com/aengdulab/distributedmail/LeaderTask.java
+++ b/src/main/java/com/aengdulab/distributedmail/LeaderTask.java
@@ -1,0 +1,45 @@
+package com.aengdulab.distributedmail;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LeaderTask {
+
+    private final DistributedSupport distributedSupport;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final List<FollowerMessage> messages = Collections.synchronizedList(new ArrayList<>());
+
+    public void start() {
+        log.info("leaderTask started");
+        sleep(5000);
+
+        distributedSupport.setIndex(1);
+        distributedSupport.setCount(messages.size() + 1);
+        for (int i = 0; i < messages.size(); i++) {
+            LeaderMessage leaderMessage = new LeaderMessage(messages.get(i).address(), messages.size() + 1, i + 2);
+            kafkaTemplate.send("leader", leaderMessage);
+        }
+    }
+
+    private void sleep(int millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @KafkaListener(topics = "loyalty", groupId = "consumerGroup-" + "#{T(java.util.UUID).randomUUID()})")
+    public void receiveMessage(FollowerMessage followerMessage) {
+        messages.add(followerMessage);
+    }
+}

--- a/src/main/java/com/aengdulab/distributedmail/repository/QuestionRepository.java
+++ b/src/main/java/com/aengdulab/distributedmail/repository/QuestionRepository.java
@@ -1,7 +1,7 @@
 package com.aengdulab.distributedmail.repository;
 
-import com.aengdulab.distributedmail.domain.Question;
 import java.util.Optional;
+import com.aengdulab.distributedmail.domain.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/com/aengdulab/distributedmail/service/SendQuestionScheduler.java
+++ b/src/main/java/com/aengdulab/distributedmail/service/SendQuestionScheduler.java
@@ -1,10 +1,17 @@
 package com.aengdulab.distributedmail.service;
 
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+import com.aengdulab.distributedmail.DistributedLock;
+import com.aengdulab.distributedmail.DistributedSupport;
+import com.aengdulab.distributedmail.FollowerTask;
+import com.aengdulab.distributedmail.LeaderTask;
 import com.aengdulab.distributedmail.domain.Subscribe;
 import com.aengdulab.distributedmail.domain.SubscribeQuestionMessage;
 import com.aengdulab.distributedmail.repository.SubscribeRepository;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -18,16 +25,48 @@ public class SendQuestionScheduler {
 
     private final QuestionSender questionSender;
     private final SubscribeRepository subscribeRepository;
+    private final DistributedLock distributedLock;
+    private final DataSource dataSource;
+    private final FollowerTask followerTask;
+    private final LeaderTask leaderTask;
+    private final DistributedSupport distributedSupport;
 
     @Transactional
     @Scheduled(cron = "0 0 9 * * *", zone = "Asia/Seoul")
     public void sendQuestion() {
-        List<Subscribe> subscribes = subscribeRepository.findAll();
-        sendQuestionMails(subscribes);
+        Connection connection;
+        try {
+            connection = dataSource.getConnection();
+            boolean isLeaderNode = distributedLock.tryLock(connection, "leader", 0);
+            detectNodes(isLeaderNode);
+            releaseLock(connection, isLeaderNode);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        } finally {
+            log.info("distributed support index = {} count = {}", distributedSupport.getIndex(), distributedSupport.getCount());
+            List<Subscribe> subscribes = subscribeRepository.findAll();
+            sendQuestionMails(subscribes);
+        }
+    }
+
+    private void detectNodes(boolean isLeaderNode) {
+        if (isLeaderNode) {
+            leaderTask.start();
+            return;
+        }
+
+        followerTask.start();
+    }
+
+    private void releaseLock(Connection connection, boolean isLeaderNode) {
+        if (isLeaderNode) {
+            distributedLock.releaseLock(connection, "leader");
+        }
     }
 
     private void sendQuestionMails(List<Subscribe> subscribes) {
         subscribes.stream()
+                .filter(subscribe -> distributedSupport.isMine(subscribe.getId()))
                 .flatMap(subscribe -> choiceQuestion(subscribe).stream())
                 .forEach(questionSender::sendQuestion);
     }

--- a/src/main/java/com/aengdulab/distributedmail/service/SubscribeQuestionSequenceScheduler.java
+++ b/src/main/java/com/aengdulab/distributedmail/service/SubscribeQuestionSequenceScheduler.java
@@ -1,10 +1,10 @@
 package com.aengdulab.distributedmail.service;
 
+import java.util.List;
 import com.aengdulab.distributedmail.domain.Question;
 import com.aengdulab.distributedmail.domain.Subscribe;
 import com.aengdulab.distributedmail.repository.QuestionRepository;
 import com.aengdulab.distributedmail.repository.SubscribeRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;

--- a/src/test/java/com/aengdulab/distributedmail/MultiServerRequestTest.java
+++ b/src/test/java/com/aengdulab/distributedmail/MultiServerRequestTest.java
@@ -37,7 +37,12 @@ class MultiServerRequestTest {
     /*
     서버를 다중화할 경우, 새로운 요청에 대한 추가 포트를 설정
      */
-    private static final List<Integer> serverPorts = List.of(8080, 9090, 9999);
+    private static final List<Integer> serverPorts = List.of(
+            8080, 8081, 8082, 8083, 8084,
+            8085, 8086, 8087, 8088, 8089,
+            8090, 8091, 8092, 8093, 8094,
+            8095, 8096, 8097, 8098, 8099
+    );
 
     @Autowired
     private SentMailEventRepository sentMailEventRepository;

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,8 +4,7 @@ spring:
     url: jdbc:mysql://localhost:13306/mail?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
     username: root
     password: root
-    hikari:
-      maximum-pool-size: 3
+
   jpa:
     properties:
       hibernate:


### PR DESCRIPTION
기본적인 구현 아이디어는 모듈러 연산인데요. 모듈러 연산의 단점을 극복하기 위한 합리적인 대안이 존재하는지 고민하기 위해서 구현했어요.
생각과 방법을 아래에 간략하게 요약해둘게요.

**맥락**
- 모듈러에 필요한 값은 `server count`, `server index` 입니다.
- 이 방식의 단점은 환경 변수를 관리하는 것입니다.
- 메일 전송 시간대에 `유동적으로 서버의 수가 변경되는 환경에서 환경 변수를 어떻게 관리하지?` 가 고민의 시작점입니다.

**구현 아이디어(리더선출-브로드캐스팅)**

1. 분산 잠금으로 리더 노드를 선출을 한다.
2. 팔로워 노드가 /loyalty 채널에 메시지를 전달한다. →  127.0.0.1:8080, 127.0.0.1:8081
3. 팔로워 노드의 메시지를 취합한 리더는 다시 메시지를 브로드캐스팅한다. (컨슈머 그룹 ID를 랜덤으로 생성해서 파티션 할당) 
    1. 127:0:0:1:8080 number = 1, count = 3
    2. 127:0:0:1:9090 number = 2 count = 3
4. 리더는 잠금을 해제한다.

**구현에 대한 문제**

- 해당 방식에서 LeaderTask를 실행하기 이전에 팔로워 메시지를 수집하는 기간인 5초를 설정했는데요. 실제 수집 시간이 5초 보다 이하인 경우, 리소스 낭비이며, 이상인 경우 누락이 발생해요. 정확한 시간을 알아내기 어렵다는 문제가 있습니다.
- 관측자 노드 프로세스를 새로 띄우느니, 리더 노드를 선출하는 방식으로 구현했어요. 전송 과정 중에서 전송 노드들이 다운 되는 것은 큰 문제가 되지 않는다고 생각해요. 발송 과정에서 노드들이 다운되는 경우에는 누락건에 대한 재전송을 수행하면 되기 때문입니다. 하지만, 리더가 다운되는 경우에는 재선출이 필요해요. 이 부분이 구현에는 빠져있으나 추가적인 구현이 복잡해질 것으로 예상됩니다.

**다른 대안**
-  서버가 실행할때, 원자적 연산 보장해주는 카운터를 증가 시킨다. 다운될떄, 카운터를 감소 시킨다. (체크인-체크아웃 방식)
    - (문제) 다운될때, 카운터를 감소 못 시킬 수도 있다.
- 관측자 노드가 주기적으로 헬스체크를 받고 전송 시간대에 참여자 노드에게 친절히 알려준다. 혹은 DB에 `server count`, `server index`를 저장한다. (관측자 방식)
 
**아무래도 이게 핵심**

어떤 방식을 사용해도, 잘못된 `server count`, `server index`가 설정되는 일이 발생할 수 있습니다. 하지만, 적어도 `server index`가 중복될 일이 없다면, 누락건에 대한 재전송은 가능하다고 생각합니다. 따라서, 제가 생각하기에는 `server index`에 노드 간 중복이 없으면서, 전체 구독자 구간에서 누락이 발생할 케이스가 가장 작은 것이 좋은 대안의 기준이라고 생각합니다. (비슷하다면, 성능을 확인), 아 근데 subscribe_id가 UUID면 어쩌지..?
